### PR TITLE
Logo dimensions fix

### DIFF
--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -28,24 +28,30 @@ $(document).ready(function(){
 		}
 	});
 	
-	// Detect logo dimensions and add correct class
+	// // Detect logo dimensions and add correct class
 	
-	var logoImage = $('.top-bar .logo:first-of-type');
+	// var logoImage = $('.top-bar .logo:first-of-type');
 	
-	var theImage = new Image();
-	theImage.src = logoImage.attr("src");
+	// var theImage = new Image();
+	// theImage.src = logoImage.attr("src");
 	
-	var logoWidth = theImage.width;
-	var logoHeight = theImage.height;
-	var logoRatio = logoWidth / logoHeight;
+	// var logoWidth = theImage.width;
+	// var logoHeight = theImage.height;
+	// var logoRatio = logoWidth / logoHeight;
 	
-	if(logoRatio > 2.8){
-		$('.top-bar .logo').addClass('logo-wide');
-	}
+	// if(logoRatio > 2.8){
+	// 	$('.top-bar .logo').addClass('logo-wide');
+	// }
 	
-	if(logoRatio < 2){
-		$('.top-bar .logo').addClass('logo-square');
-	}
+	// if(logoRatio < 2){
+	// 	$('.top-bar .logo').addClass('logo-square');
+	// }
+    
+    // Can't detect the logo dimensions until the actual image is loaded,
+    // which happens after $(document).ready() since it's a remote resource.
+    // Hard-code the "logo-wide" class, since it's a wide (and not square) logo
+    
+    $('.top-bar .logo').addClass('logo-wide');
 	
 	// Smooth scroll
 	


### PR DESCRIPTION
As per https://github.com/jsIsrael/JavaScript-Israel-Website/issues/1#issuecomment-166770136, fixed the weird logo dimensions bug which is present on http://www.jsisrael.com.

It occurred because the Pivot template's JS code tried to detect the logo's aspect ratio before the image was loaded.

We can't detect the logo dimensions until the actual image is loaded, which happens after `$(document).ready()` since it's a remote resource.

To work around this, we can hard-code the `logo-wide` class, since we know that our logo is wide (and not square) in its dimensions.

After the fix was applied:
![fix](https://cloud.githubusercontent.com/assets/4394189/11984102/3dd9aca8-a9c1-11e5-840e-d6dbc1666c97.png)
