### PR TITLE
Fix header menu and links CSS positioning

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -45,8 +45,19 @@ img.team-image {
 
 /* Header border bottom */
 .row.nav-menu {
-	padding-bottom: 18px;
+	padding-bottom: 5px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+/* Header menu top positioning */
+.nav-menu .menu {
+    top: 8px;
+}
+
+/* Header external links positioning */
+.nav-menu .social-icons
+{
+    padding-top: 6px;
 }
 
 /* Workarounds for the JavaScript vertical align / fullscreen height functions */


### PR DESCRIPTION
The header menu was incorrectly aligned with the logo and external links.

Modified the `custom.css` file as follows:
- Lowered the separator line, so it looks a little better.
- Padded the menu from the top.
- Padded the external links from the top.

See the attached photo (after the changes):
![header-fix](https://cloud.githubusercontent.com/assets/4394189/11984086/1ccb25c8-a9c1-11e5-8b21-8891aad33fe5.png)
